### PR TITLE
Fix: Replace deprecated `printTime` with `dateTimeFormat` in logger configuration

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -10,7 +10,7 @@ Logger _getLogger() {
       lineLength: 50,
       colors: true,
       printEmojis: true,
-      printTime: false,
+      dateTimeFormat: DateTimeFormat.none,
     ),
   );
 }


### PR DESCRIPTION
This PR updates the logger configuration in response to a deprecation warning introduced in the latest version of the logger plugin.

Changes:
Removed the deprecated printTime: false configuration.

Added dateTimeFormat: DateTimeFormat.none to maintain the same behavior (no timestamp in logs).

Reason:
The printTime property is now deprecated and should be replaced with dateTimeFormat. This ensures the project remains compatible with future versions of the logger package.

🔗 Reference:
[Logger printTime deprecation notice](https://pub.dev/documentation/logger/latest/logger/PrettyPrinter/printTime.html)